### PR TITLE
Add SwiftUI risk prevention example app

### DIFF
--- a/RiskPreventionApp/ContentView.swift
+++ b/RiskPreventionApp/ContentView.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+struct ContentView: View {
+    @State private var helmet = false
+    @State private var gloves = false
+    @State private var boots = false
+    @State private var incidentText = ""
+    @Environment(\.openURL) private var openURL
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section(header: Text("Chequeo de EPIs")) {
+                    Toggle("Casco", isOn: $helmet)
+                    Toggle("Guantes", isOn: $gloves)
+                    Toggle("Botas de seguridad", isOn: $boots)
+                }
+                Section(header: Text("Incidencias")) {
+                    TextEditor(text: $incidentText)
+                        .frame(height: 100)
+                }
+                Button("Enviar reporte") {
+                    sendReport()
+                }
+            }
+            .navigationTitle("Prevención")
+        }
+    }
+
+    private func sendReport() {
+        var body = "Casco: \(helmet ? \"Sí\" : \"No\")\n"
+        body += "Guantes: \(gloves ? \"Sí\" : \"No\")\n"
+        body += "Botas de seguridad: \(boots ? \"Sí\" : \"No\")\n\n"
+        body += "Incidencias:\n\(incidentText)"
+
+        let subject = "Chequeo EPIs"
+        let address = "marlenwow@icloud.com"
+        let urlString = "mailto:\(address)?subject=\(subject.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")&body=\(body.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")"
+        if let url = URL(string: urlString) {
+            openURL(url)
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/RiskPreventionApp/README.md
+++ b/RiskPreventionApp/README.md
@@ -1,0 +1,11 @@
+# RiskPreventionApp
+
+Este es un ejemplo simple de una aplicación iOS escrita en SwiftUI para que los trabajadores registren el estado de sus equipos de protección individual (EPI) e indiquen incidencias.
+
+Al pulsar el botón **Enviar reporte** se abrirá el cliente de correo con un mensaje dirigido a `marlenwow@icloud.com` que contiene la información introducida.
+
+## Uso
+
+1. Abre la carpeta `RiskPreventionApp` con Xcode (puedes crear un nuevo proyecto tipo *App* y reemplazar los archivos generados por estos).
+2. Ejecuta la aplicación en un iPhone o simulador.
+3. Marca los EPIs disponibles, escribe las incidencias y pulsa **Enviar reporte**.

--- a/RiskPreventionApp/RiskPreventionApp.swift
+++ b/RiskPreventionApp/RiskPreventionApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct RiskPreventionApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `RiskPreventionApp` example folder
- implement a simple SwiftUI view to mark PPE and send an email report
- document how to use the sample app

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687890fc76048324bd100f9a7a1426f9